### PR TITLE
Add all gcc versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,19 @@ env:
   - BINARYBUILDER_AUTOMATIC_APPLE=true
     # Our build takes too long for one job, so split targets across multiple jobs
   matrix:
-    - TARGET=x86_64-linux-gnu
-    - TARGET=i686-linux-gnu
-    - TARGET=x86_64-linux-musl
-    - TARGET=i686-linux-musl
-    - TARGET=aarch64-linux-gnu
-    - TARGET=aarch64-linux-musl
-    - TARGET=arm-linux-gnueabihf
-    - TARGET=arm-linux-musleabihf
-    - TARGET=powerpc64le-linux-gnu
-    - TARGET=x86_64-apple-darwin14
-    - TARGET=x86_64-unknown-freebsd11.1
-    - TARGET=x86_64-w64-mingw32
-    - TARGET=i686-w64-mingw32
+    - PART=1/13
+    - PART=2/13
+    - PART=3/13
+    - PART=4/13
+    - PART=5/13
+    - PART=6/13
+    - PART=7/13
+    - PART=8/13
+    - PART=9/13
+    - PART=10/13
+    - PART=11/13
+    - PART=12/13
+    - PART=13/13
 
 sudo: required
 
@@ -43,7 +43,7 @@ jobs:
 before_script:
 - julia -e 'using Pkg; pkg"add BinaryProvider"; pkg"add BinaryBuilder#master"; Pkg.build()'
 script:
-- julia  --color=yes build_tarballs.jl $TARGET
+- julia  --color=yes build_tarballs.jl --part=$PART
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,19 +17,26 @@ env:
   - BINARYBUILDER_AUTOMATIC_APPLE=true
     # Our build takes too long for one job, so split targets across multiple jobs
   matrix:
-    - PART=1/13
-    - PART=2/13
-    - PART=3/13
-    - PART=4/13
-    - PART=5/13
-    - PART=6/13
-    - PART=7/13
-    - PART=8/13
-    - PART=9/13
-    - PART=10/13
-    - PART=11/13
-    - PART=12/13
-    - PART=13/13
+    - PART=1/20
+    - PART=2/20
+    - PART=3/20
+    - PART=4/20
+    - PART=5/20
+    - PART=6/20
+    - PART=7/20
+    - PART=8/20
+    - PART=9/20
+    - PART=10/20
+    - PART=11/20
+    - PART=12/20
+    - PART=13/20
+    - PART=14/20
+    - PART=15/20
+    - PART=16/20
+    - PART=17/20
+    - PART=18/20
+    - PART=19/20
+    - PART=20/20
 
 sudo: required
 

--- a/build_tarballs.jl
+++ b/build_tarballs.jl
@@ -42,6 +42,7 @@ fi
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
 platforms = supported_platforms()
+platforms = expand_gcc_versions(platforms)
 
 # The products that we will ensure are always built
 products(prefix) = [
@@ -83,7 +84,7 @@ products(prefix) = [
 
 # Dependencies that must be installed before this package can be built
 dependencies = [
-    
+
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.


### PR DESCRIPTION
This PR adds all GCC versions to the release. It takes longer for the build to complete, but is a more complete release of the binaries.

https://travis-ci.com/kdheepak/boostBuilder/builds/130594835

I require this since I would like gcc with C++14 features, which the default 4.8.5 build does not have.

I thought I'd check if you would you be interested in merging this PR? If not, I'll be happy to maintain my fork of this repository.